### PR TITLE
refactor: Some vita optimizations

### DIFF
--- a/src/gl11.c
+++ b/src/gl11.c
@@ -99,7 +99,13 @@ void gl_end_drawscene(Client *c) {
     #ifdef __vita__
         viewport_xoff += SCREEN_CENTER_XOFF;
     #endif
-        glViewport(viewport_xoff, SCREEN_FB_HEIGHT - 11 - _Pix2D.height, _Pix2D.width - 1, _Pix2D.height);
+        int viewport_yoff = SCREEN_FB_HEIGHT - 11 - _Pix2D.height;
+        int viewport_width = _Pix2D.width - 1;
+        int viewport_height = _Pix2D.height;
+
+        glViewport(viewport_xoff, viewport_yoff, viewport_width, viewport_height);
+        glEnable(GL_SCISSOR_TEST);
+        glScissor(viewport_xoff, viewport_yoff, viewport_width, viewport_height);
         glBindTexture(GL_TEXTURE_2D, texture_atlas);
 
         glColorPointer(4, GL_UNSIGNED_BYTE, sizeof(Vertex), &verts[0].r);
@@ -121,6 +127,7 @@ void gl_end_drawscene(Client *c) {
         elementcount = 0;
 
         glViewport(0, 0, SCREEN_FB_WIDTH, SCREEN_FB_HEIGHT);
+        glDisable(GL_SCISSOR_TEST);
 
         glPopMatrix();
         glMatrixMode(GL_PROJECTION);

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -55,6 +55,18 @@ typedef struct {
 #define MAX_IDX_NUMBER 0xC000 // for vitaGL compat
 Point pixels[MAX_IDX_NUMBER]; // area_viewport pixels
 int pixcount = 0;
+
+// tcc has no builtins, and a prefetch is only ever a hint
+#if defined(__GNUC__) && !defined(__TINYC__)
+#define PIXMAP_PREFETCH(addr) __builtin_prefetch(addr)
+#else
+#define PIXMAP_PREFETCH(addr) ((void)0)
+#endif
+
+static inline void push_point(uint32_t rgb, int sx, int sy) {
+    Point p = {(rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff, sx, sy};
+    pixels[pixcount++] = p;
+}
 #endif
 
 void pixmap_draw(PixMap *pixmap, int x, int y) {
@@ -66,19 +78,51 @@ void pixmap_draw(PixMap *pixmap, int x, int y) {
     extern bool use_opengl11; // use global bool instead of _Custom.use_opengl11 (force disabled after scene render)
     // this path is for few pixels, if use_opengl11 was disabled area_viewport contains the entire scene as well
     if (use_opengl11 && pixmap->width == 512) { // area_viewport pixmap is usually dirty while often drawing NOTHING
+        const uint32_t *src = (const uint32_t *)pixmap->pixels;
+        const int width = pixmap->width;
+        const int height = pixmap->height;
+
         pixcount = 0; // reset pixcount b4 loop as it's drawn on screen later
-        for (int py = 0; py < pixmap->height; py++) {
-            if (pixcount >= MAX_IDX_NUMBER - pixmap->width) { // might not reach MAX_IDX_NUMBER but prefer outer loop check
+        for (int py = 0; py < height; py++) {
+            if (pixcount >= MAX_IDX_NUMBER - width) { // might not reach MAX_IDX_NUMBER but prefer outer loop check
                 goto draw_texture;
             }
 
-            for (int px = 0; px < pixmap->width; px++) {
-                uint32_t rgb = pixmap->pixels[py * pixmap->width + px];
+#if 1
+            const uint32_t *row = src + py * width;
+            int px = 0;
+
+            // process 4 pixels at a time
+            for (; px + 3 < width; px += 4) {
+                PIXMAP_PREFETCH(row + px + 64); // this hint measurably improves access on vita
+
+                if ((row[px] & row[px + 1] & row[px + 2] & row[px + 3]) == 0xffffffff) {
+                    continue;
+                }
+
+                // optimization will unroll this
+                for (int i = 0; i < 4; i++) {
+                    if (row[px + i] != 0xffffffff) {
+                        push_point(row[px + i], x + px + i, y + py);
+                    }
+                }
+            }
+
+            // process remainder (if width is not / 4)
+            for (; px < width; px++) {
+                if (row[px] != 0xffffffff) {
+                    push_point(row[px], x + px, y + py);
+                }
+            }
+#else
+            for (int px = 0; px < >width; px++) {
+                uint32_t rgb = src[py * width + px];
                 if (rgb != 0xffffffff) {
                     Point p = {(rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff, x + px, y + py};
                     pixels[pixcount++] = p;
                 }
             }
+#endif
         }
 
         if (pixcount > 0) {
@@ -101,6 +145,18 @@ void pixmap_draw(PixMap *pixmap, int x, int y) {
         // rs2_log("dirty pixmap id %d width %d height %d\n", pixmap->gl_texture, pixmap->width, pixmap->height);
         pixmap->dirty = false;
 
+#if 1
+        const uint32_t *restrict src = (const uint32_t *)pixmap->pixels;
+        uint32_t *restrict dst = (uint32_t *)pixmap->gl_pixels;
+        const int count = pixmap->width * pixmap->height;
+
+        // with -O3 this becomes SIMD (vector instructions)
+        for (int i = 0; i < count; i++) {
+            uint32_t rgb = src[i];
+            uint32_t drawn = (uint32_t)0 - (uint32_t)(rgb != 0xffffffff);
+            dst[i] = (rgb | 0xff000000) & drawn;
+        }
+#else
         for (int i = 0; i < pixmap->width * pixmap->height; i++) {
             uint32_t rgb = pixmap->pixels[i];
             if (rgb == 0xffffffff) {
@@ -110,6 +166,7 @@ void pixmap_draw(PixMap *pixmap, int x, int y) {
             }
             pixmap->gl_pixels[i] = rgb;
         }
+#endif
         glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, pixmap->width, pixmap->height, GL_BGRA_EXT, GL_UNSIGNED_BYTE, pixmap->gl_pixels);
     }
 

--- a/src/platform/vita.c
+++ b/src/platform/vita.c
@@ -39,8 +39,15 @@ static int mutex;
 
 static uint64_t systemtime_start = 0;
 
-static SceTouchData touch[SCE_TOUCH_PORT_MAX_NUM], touch_old[SCE_TOUCH_PORT_MAX_NUM];
+#define CPU_AFFINITY_CORE0 0x10000
+#define CPU_AFFINITY_CORE1 0x20000
+#define CPU_AFFINITY_CORE2 0x40000
+
+static SceTouchData touch[SCE_TOUCH_PORT_MAX_NUM];
 static SceCtrlData ctrl, ctrl_old;
+
+static int touch_max_x = 1920;
+static int touch_max_y = 1088;
 
 #define AUDIO_PORT_SAMPLES 1024
 static int g_AudioPort = -1;
@@ -269,7 +276,7 @@ static void midi_audio_init(void) {
     }
 
     g_MidiActive = true;
-    g_AudioThread = sceKernelCreateThread("audio", audio_thread_main, 0x10000100, AUDIO_THREAD_STACK, 0, SCE_KERNEL_THREAD_CPU_AFFINITY_MASK_DEFAULT, NULL);
+    g_AudioThread = sceKernelCreateThread("audio", audio_thread_main, 0x10000100, AUDIO_THREAD_STACK, 0, CPU_AFFINITY_CORE2, NULL);
     int thread_start_result = g_AudioThread >= 0 ? sceKernelStartThread(g_AudioThread, 0, NULL) : -1;
     if (g_AudioThread < 0 || thread_start_result < 0) {
         g_MidiActive = false;
@@ -363,6 +370,10 @@ bool platform_init(void) {
 void platform_new(GameShell *shell) {
     (void)shell;
 
+    // core 0 - game
+    // core 1 - vitaGL gc
+    // core 2 - audio
+
     scePowerSetArmClockFrequency(444);
     scePowerSetBusClockFrequency(222);
     scePowerSetGpuClockFrequency(222);
@@ -371,9 +382,10 @@ void platform_new(GameShell *shell) {
     systemtime_start = sceKernelGetSystemTimeWide();
 
 #ifdef GL11
+    vglSetupGarbageCollector(0x10000100, CPU_AFFINITY_CORE1);
     vglSetCircularPoolSize(64 * 1024 * 1024);
-    vglInit(0x800000);
-    vglWaitVblankStart(GL_TRUE);
+    vglInitExtended(0x800000, SCREEN_FB_WIDTH, SCREEN_FB_HEIGHT, 0x1000000, SCE_GXM_MULTISAMPLE_NONE);
+    vglWaitVblankStart(GL_FALSE);
 #else
     mutex = sceKernelCreateMutex("fb_mutex", 0, 0, NULL);
     displayblock = sceKernelAllocMemBlock("display", SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW, SCREEN_FB_SIZE, NULL);
@@ -384,8 +396,16 @@ void platform_new(GameShell *shell) {
     sceDisplaySetFrameBuf(&frame, SCE_DISPLAY_SETBUF_NEXTFRAME);
 #endif
 
+    sceKernelChangeThreadCpuAffinityMask(sceKernelGetThreadId(), CPU_AFFINITY_CORE0);
+
     sceTouchSetSamplingState(SCE_TOUCH_PORT_FRONT, SCE_TOUCH_SAMPLING_STATE_START);
     // sceTouchSetSamplingState(SCE_TOUCH_PORT_BACK, SCE_TOUCH_SAMPLING_STATE_START);
+
+    SceTouchPanelInfo info;
+    if (sceTouchGetPanelInfo(SCE_TOUCH_PORT_FRONT, &info) >= 0 && info.maxAaX > 0 && info.maxAaY > 0) {
+        touch_max_x = info.maxAaX;
+        touch_max_y = info.maxAaY;
+    }
 
     // sceCtrlSetSamplingMode(SCE_CTRL_MODE_ANALOG);
     sceCtrlSetSamplingMode(SCE_CTRL_MODE_DIGITAL);
@@ -524,18 +544,13 @@ void platform_stop_midi(void) {
 void platform_poll_events(Client *c) {
     static bool right_click = false;
 
-    static SceTouchPanelInfo info;
-    sceTouchGetPanelInfo(SCE_TOUCH_PORT_FRONT, &info);
-
-    memcpy(touch_old, touch, sizeof(touch_old));
-
     for (int port = 0; port < 1 /* SCE_TOUCH_PORT_MAX_NUM */; port++) {
         sceTouchPeek(port, &touch[port], 1);
         for (int i = 0; i < 1 /* SCE_TOUCH_MAX_REPORT */; i++) {
             static bool touch_down = false;
             if (touch[port].reportNum > 0) {
-                int x = touch[port].report[i].x * SCREEN_FB_WIDTH / info.maxAaX - SCREEN_CENTER_XOFF;
-                int y = touch[port].report[i].y * SCREEN_FB_HEIGHT / info.maxAaY;
+                int x = touch[port].report[i].x * SCREEN_FB_WIDTH / touch_max_x - SCREEN_CENTER_XOFF;
+                int y = touch[port].report[i].y * SCREEN_FB_HEIGHT / touch_max_y;
 
                 c->shell->idle_cycles = 0;
                 c->shell->mouse_x = x;

--- a/vita.mk
+++ b/vita.mk
@@ -43,12 +43,14 @@ CFLAGS += -DWITH_RSA_LIBTOM
 endif
 
 CFLAGS += -D$(PROJECT)
-CFLAGS += -Wl,-q -std=c99
+CFLAGS += -Wl,-q -std=c99 -marm
+DEPFLAGS := -MMD -MP
 
 SOURCES := $(call rwildcard, src/, *.c)
 
 OBJ_DIRS := $(sort $(addprefix out/, $(dir $(SOURCES:src/%.c=%.o))))
 OBJS := $(addprefix out/, $(SOURCES:src/%.c=%.o))
+DEPS := $(OBJS:.o=.d)
 
 all: package
 
@@ -82,8 +84,10 @@ $(OBJ_DIRS):
 	@mkdir -p $@
 
 out/%.o : src/%.c | $(OBJ_DIRS)
-	$(CC) -c $(CFLAGS) -o $@ $<
+	$(CC) -c $(CFLAGS) $(DEPFLAGS) -o $@ $<
+
+-include $(DEPS)
 
 clean:
 	rm -f $(PROJECT).velf $(PROJECT).elf $(PROJECT).vpk param.sfo eboot.bin $(OBJS)
-	rm -r $(abspath $(OBJ_DIRS))
+	rm -rf $(abspath $(OBJ_DIRS))


### PR DESCRIPTION
Just some ideas I had.

1. Thread affinities pinned to separate cores
- Game Loop thread (core 0)
- vitaGL garbage collection thread (core 1)
- Game Audio thread (core 2)
2. `SceTouchPanelInfo` is always the same so it's now cached on startup
3. No MSAA for vitaGL so it's as sharp as CPU rendering
4. Disabled vitaGL Vblank since at best it hurts performance here
5. (fix) It appears that glViewport is simply a transform, it doesn't set rasterization bounds. glScissor is needed on vita or it overdraws
6. Optimized the PixMap drawing loops. The viewport test advances 4 pixels at once, and the dirty loop can optimize into SIMD to draw 4-16 pixels at once (4 on vita, 16 on macOS). 5-6 ms becomes 1-2 ms

More significant vita gains will have to come improving from the GL backend. Hotspots are World3D and the minimap.